### PR TITLE
Fix missing BLOCK_SIZE import in piece manager

### DIFF
--- a/piece_manager.py
+++ b/piece_manager.py
@@ -1,6 +1,7 @@
 import hashlib
 import threading
 from utils import logger
+from constants import BLOCK_SIZE
 
 # -----------------------------------------------------------
 # クラス：PieceManager


### PR DESCRIPTION
## Summary
- Import BLOCK_SIZE constant in PieceManager to prevent NameError when requesting blocks

## Testing
- `python -m py_compile piece_manager.py`
- `pytest -q` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_689667056194832eaa30c9fdb9b27225