### PR TITLE
Add DHT and basic PEX support

### DIFF
--- a/dht.py
+++ b/dht.py
@@ -1,0 +1,46 @@
+import os
+import socket
+import bencodepy
+from utils import logger
+
+BOOTSTRAP_NODES = [
+    ("router.bittorrent.com", 6881),
+    ("dht.transmissionbt.com", 6881),
+    ("router.utorrent.com", 6881),
+]
+
+
+class DHTClient:
+    """Simple DHT client for retrieving peers via get_peers"""
+
+    def __init__(self, node_id: bytes = None):
+        self.node_id = node_id or os.urandom(20)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.settimeout(3)
+
+    def _build_get_peers(self, tid: bytes, info_hash: bytes) -> bytes:
+        return bencodepy.encode({
+            b"t": tid,
+            b"y": b"q",
+            b"q": b"get_peers",
+            b"a": {b"id": self.node_id, b"info_hash": info_hash},
+        })
+
+    def get_peers(self, info_hash: bytes):
+        peers = []
+        for host, port in BOOTSTRAP_NODES:
+            try:
+                tid = os.urandom(2)
+                msg = self._build_get_peers(tid, info_hash)
+                self.sock.sendto(msg, (host, port))
+                data, _ = self.sock.recvfrom(2048)
+                resp = bencodepy.decode(data)
+                r = resp.get(b"r", {})
+                if b"values" in r:
+                    for entry in r[b"values"]:
+                        ip = ".".join(str(b) for b in entry[:4])
+                        peer_port = int.from_bytes(entry[4:], "big")
+                        peers.append((ip, peer_port))
+            except Exception as e:
+                logger.debug("DHT問い合わせ失敗: %s:%s %s", host, port, e)
+        return peers


### PR DESCRIPTION
## Summary
- add simple DHT client to discover peers without trackers
- integrate DHT lookup into torrent client and process PEX messages

## Testing
- `python -m py_compile client.py peer.py dht.py`


------
https://chatgpt.com/codex/tasks/task_e_68966705589c832eaf0bb871c2a2d03f